### PR TITLE
smol fix in reentrantAware_multiDepth test

### DIFF
--- a/test/TransientContext.t.sol
+++ b/test/TransientContext.t.sol
@@ -170,7 +170,7 @@ contract TransientReentrancyAwareTest is TransientContextTest, TransientReentran
         uint256 _value1,
         uint256 _value2
     ) public {
-        vm.assume(_callDepth < type(uint256).max - 1);
+        vm.assume(_callDepth < type(uint256).max - 2);
         assembly ("memory-safe") {
             tstore(sload(callDepthSlot.slot), _callDepth)
         }


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

very smol fix on the `reentrantAware_multiDepth` test - since `callDepth` is being incremented twice, the `vm.assume` should make sure to only take values _2_ less than `Type(uint256).max` to ensure the second incrementation doesn't overflow

**Tests**

This is a smol edit in a test, and does not necessitate additional tests

**Additional context**

Since Foundry smart fuzzes, this will avoid cases where the fuzzer reuses `Type(uint256).max - 1` since it's used elsewhere.
